### PR TITLE
Fix #1 - Crash in multiplayer when pressing H

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,32 +22,25 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Read and extract versions from gradle.properties
-        id: extract-versions
-        run: |
-          VERSION=$(grep 'mod_version=' gradle.properties | cut -d'=' -f2 | tr -d '[:space:]')
-          MINECRAFT_VERSION=$(grep 'minecraft_version=' gradle.properties | cut -d'=' -f2 | tr -d '[:space:]')
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "MINECRAFT_VERSION=${MINECRAFT_VERSION}" >> $GITHUB_ENV
+      - name: Read properties from gradle.properties
+        id: read_properties
+        uses: christian-draeger/read-properties@1.1.1
+        with:
+          path: gradle.properties
+          properties: minecraft_version mod_version
 
       - name: Build artifacts
         run: ./gradlew clean build
 
       - uses: Kir-Antipov/mc-publish@v3.3
         with:
-          modrinth-id: JGYH59f7
-          modrinth-token: ${{ secrets.TOKEN_MODRINTH }}
-
-          github-tag: mc${{ env.MINECRAFT_VERSION }}-${{ env.VERSION }}
-          github-prerelease: true
-          github-token: ${{ secrets.TOKEN_GITHUB }}
-
-          name: Redstonery Mod ${{ env.VERSION }} for Minecraft ${{ env.MINECRAFT_VERSION }}
-          version: mc${{ env.MINECRAFT_VERSION }}-${{ env.VERSION }}
+          name: Redstonery Mod ${{ steps.read_properties.outputs.mod_version }} for Minecraft ${{ steps.read_properties.outputs.minecraft_version }}
+          version: mc${{ steps.read_properties.outputs.minecraft_version }}-${{ steps.read_properties.outputs.mod_version }}
           version-type: alpha
           changelog-file: CHANGELOG_NEWEST.md
 
-          loaders: |
-            fabric
-          game-versions: |
-            ${{ env.MINECRAFT_VERSION }}
+          modrinth-id: JGYH59f7
+          modrinth-token: ${{ secrets.TOKEN_MODRINTH }}
+
+          github-token: ${{ secrets.TOKEN_GITHUB }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ bin/
 
 run/
 
+# server
+
+server/
+
 # java
 
 hs_err_*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.0.3 Bug fix update
+### Bug fixes:
+- Fix #1 (`Crash in multiplayer when pressing H`)
+### Features:
+- The two panorama buttons are now available in multiplayer screen (server selection)
+### Other Changes:
+- Extend utility static methods to `PanoramaClient`
+- Make a few changes to the `main.yml` workflow making it simpler and more automatic
+- Disable the remove panorama button when no panorama is applied
+
 # v0.0.2 The button textures update
 ### Features:
 - Now the (formerly) "P" and "R" buttons have proper textures ot them

--- a/CHANGELOG_NEWEST.md
+++ b/CHANGELOG_NEWEST.md
@@ -1,9 +1,8 @@
+### Bug fixes:
+- Fix #1 (`Crash in multiplayer when pressing H`)
 ### Features:
-- Now the (formerly) "P" and "R" buttons have proper textures ot them
-- Change `panoramas_button` texture to `load_panoramas_button`
-- Add `remove_panoramas_button` texture
+- The two panorama buttons are now available in multiplayer screen (server selection)
 ### Other Changes:
-- Simplified / resolved positioning of buttons
-- Removed unused code (unused panoramas options screen)
-- The changelog loaded to Modrinth is now named `CHANGELOG_NEWEST.md` and contains only the newest version without the version header (the main `CHANGELOG.md` remains)
-- Added links to the mod's GitHub page
+- Extend utility static methods to `PanoramaClient`
+- Make a few changes to the `main.yml` workflow making it simpler and more automatic
+- Disable the remove panorama button when no panorama is applied

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.4+build.3
 loader_version=0.15.2
 
 # Mod Properties
-mod_version=0.0.2
+mod_version=0.0.3
 maven_group=com.panoramas
 archives_base_name=panoramas
 

--- a/src/client/java/com/panoramas/PanoramasClient.java
+++ b/src/client/java/com/panoramas/PanoramasClient.java
@@ -37,8 +37,17 @@ public class PanoramasClient implements ClientModInitializer {
 	public void onInitializeClient() {
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
 			if (createPanorama.wasPressed()) {
-				String resourcepackBaseName = "Panorama_"
-						+ client.getServer().getSavePath(WorldSavePath.ROOT).getParent().getFileName().toString();
+				ModConfig config = GetConfig();
+
+				String levelName = null;
+
+				if (client.isInSingleplayer()) {
+					levelName = client.getServer().getSavePath(WorldSavePath.ROOT).getParent().getFileName().toString();
+				} else {
+					levelName = client.getCurrentServerEntry().address;
+				}
+
+				String resourcepackBaseName = "Panorama_" + levelName;
 
 				if (FabricLoader.getInstance().getGameDir().resolve("resourcepacks/"
 						+ resourcepackBaseName)
@@ -53,8 +62,6 @@ public class PanoramasClient implements ClientModInitializer {
 								+ "/assets/minecraft/textures/gui/title/background");
 
 				panoramasPath.toFile().mkdirs();
-
-				ModConfig config = GetConfig();
 
 				try {
 					int resolution = config.resolution;

--- a/src/client/java/com/panoramas/PanoramasClient.java
+++ b/src/client/java/com/panoramas/PanoramasClient.java
@@ -4,18 +4,23 @@ import java.io.File;
 import java.io.FileWriter;
 import java.nio.file.Path;
 
+import java.util.Collection;
+
 import org.apache.commons.io.FileUtils;
 import org.lwjgl.glfw.GLFW;
 
 import com.google.gson.Gson;
+
 import com.panoramas.config.ModConfig;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.SharedConstants;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.pack.PackListWidget.ResourcePackEntry;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.ScreenshotRecorder;
+import net.minecraft.resource.ResourcePackManager;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.text.Text;
 import net.minecraft.util.WorldSavePath;
@@ -125,6 +130,40 @@ public class PanoramasClient implements ClientModInitializer {
 		File panoramasIdentifier = FabricLoader.getInstance().getGameDir()
 				.resolve("resourcepacks/" + packName.replace("file/", "") + "/.panoramas").toFile();
 		return panoramasIdentifier.exists();
+	}
+
+	public static boolean isAnyPanoramasResourcePackLoaded() {
+		ResourcePackManager manager = MinecraftClient.getInstance().getResourcePackManager();
+
+		Collection<String> enabedPacks = manager.getEnabledNames();
+
+		for (String pack : enabedPacks) {
+			if (FabricLoader.getInstance().getGameDir()
+					.resolve("resourcepacks/" + pack.replace("file/", "") + "/.panoramas")
+					.toFile().exists()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static boolean isPanoramasResourcePackLoaded(String packName) {
+		ResourcePackManager manager = MinecraftClient.getInstance().getResourcePackManager();
+
+		Collection<String> enabedPacks = manager.getEnabledNames();
+
+		for (String pack : enabedPacks) {
+			if (pack.replace("file/", "") != packName) continue;
+
+			if (FabricLoader.getInstance().getGameDir()
+					.resolve("resourcepacks/" + pack.replace("file/", "") + "/.panoramas")
+					.toFile().exists()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public static ModConfig GetConfig() {

--- a/src/client/java/com/panoramas/mixin/client/MultiplayerScreenMixin.java
+++ b/src/client/java/com/panoramas/mixin/client/MultiplayerScreenMixin.java
@@ -1,0 +1,115 @@
+package com.panoramas.mixin.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.panoramas.Panoramas;
+import com.panoramas.PanoramasClient;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget.Entry;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget.LanServerEntry;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget.ServerEntry;
+import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.resource.ResourcePackManager;
+import net.minecraft.resource.ResourcePackProfile;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+@Mixin(MultiplayerScreen.class)
+public class MultiplayerScreenMixin extends Screen {
+    protected MultiplayerScreenMixin(Text title) {
+        super(title);
+    }
+
+    private ButtonWidget loadPanoramaButton;
+
+    private ButtonWidget removePanoramaButton;
+
+    @Shadow
+    protected MultiplayerServerListWidget serverListWidget;
+
+    @Inject(method = "init", at = @At("HEAD"))
+    private void initInjected(CallbackInfo info) {
+        loadPanoramaButton = addDrawableChild(
+                ButtonWidget.builder(ScreenTexts.EMPTY, button -> {
+                    Entry entry = serverListWidget.getSelectedOrNull();
+
+                    String packName = "";
+
+                    if (entry instanceof LanServerEntry) {
+                        packName = ((LanServerEntry) entry).getLanServerEntry().getAddressPort();
+                    } else if (entry instanceof ServerEntry) {
+                        packName = ((ServerEntry) entry).getServer().address;
+                    }
+
+                    client.getResourcePackManager().enable("file/Panorama_"
+                            + packName);
+                    client.options.refreshResourcePacks(client.getResourcePackManager());
+                }).dimensions(this.width / 2 + 158, this.height - 30, 20, 20).build());
+
+        removePanoramaButton = addDrawableChild(ButtonWidget.builder(ScreenTexts.EMPTY, button -> {
+            ResourcePackManager manager = client.getResourcePackManager();
+
+            for (ResourcePackProfile pack : manager.getProfiles()) {
+                if (PanoramasClient.isPanoramasResourcePack(pack.getName())) {
+                    manager.disable(pack.getName());
+                }
+            }
+
+            client.options.refreshResourcePacks(manager);
+        }).dimensions(this.width / 2 + 182, this.height - 30, 20, 20).build());
+    }
+
+    @Inject(method = "tick", at = @At("TAIL"))
+    public void tickInjected(CallbackInfo info) {
+        Entry entry = serverListWidget.getSelectedOrNull();
+        if (entry != null) {
+            String packName = "";
+
+            if (entry instanceof LanServerEntry) {
+                packName = ((LanServerEntry) entry).getLanServerEntry().getAddressPort();
+            } else if (entry instanceof ServerEntry) {
+                packName = ((ServerEntry) entry).getServer().address;
+            }
+
+            if (PanoramasClient.hasPanoramaPack(packName)) {
+                loadPanoramaButton.active = true;
+                loadPanoramaButton.setTooltip(Tooltip.of(Text.literal("NO TOOLTIP")));
+            } else {
+                loadPanoramaButton.active = false;
+                loadPanoramaButton.setTooltip(Tooltip
+                        .of(Text.translatable("panoramas.pack_button.no_panorama",
+                                Text.keybind("key.panoramas.create"))));
+            }
+        } else {
+            loadPanoramaButton.active = false;
+            loadPanoramaButton.setTooltip(Tooltip.of(Text.translatable("panoramas.pack_button.server_is_lan")));
+        }
+
+        removePanoramaButton.active = PanoramasClient.isAnyPanoramasResourcePackLoaded();
+    }
+
+    @Inject(method = "render", at = @At("TAIL"))
+    public void renderInjected(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo info) {
+        Identifier loadPanoramasButtonTextureLocation = new Identifier(Panoramas.MOD_ID, "load_panoramas_button");
+
+        context.drawGuiTexture(loadPanoramasButtonTextureLocation, loadPanoramaButton.getX(),
+                loadPanoramaButton.getY(), loadPanoramaButton.getWidth(),
+                loadPanoramaButton.getHeight());
+
+        Identifier removePanoramasButtonTextureLocation = new Identifier(Panoramas.MOD_ID, "remove_panoramas_button");
+
+        context.drawGuiTexture(removePanoramasButtonTextureLocation, removePanoramaButton.getX(),
+                removePanoramaButton.getY(), removePanoramaButton.getWidth(),
+                removePanoramaButton.getHeight());
+    }
+}

--- a/src/client/java/com/panoramas/mixin/client/SelectWorldScreenMixin.java
+++ b/src/client/java/com/panoramas/mixin/client/SelectWorldScreenMixin.java
@@ -94,5 +94,7 @@ public class SelectWorldScreenMixin extends Screen {
         context.drawGuiTexture(removePanoramasButtonTextureLocation, removePanoramaButton.getX(),
                 removePanoramaButton.getY(), removePanoramaButton.getWidth(),
                 removePanoramaButton.getHeight());
+
+        removePanoramaButton.active = PanoramasClient.isAnyPanoramasResourcePackLoaded();
     }
 }

--- a/src/client/resources/panoramas.client.mixins.json
+++ b/src/client/resources/panoramas.client.mixins.json
@@ -2,7 +2,11 @@
 	"required": true,
 	"package": "com.panoramas.mixin.client",
 	"compatibilityLevel": "JAVA_17",
-	"client": ["PackScreenMixin", "SelectWorldScreenMixin"],
+	"client": [
+		"PackScreenMixin",
+		"SelectWorldScreenMixin",
+		"MultiplayerScreenMixin"
+	],
 	"injectors": {
 		"defaultRequire": 1
 	}


### PR DESCRIPTION
This PR fixes #1 by detecting when the player is on the server and using the correct list entries.
Additionally there are now panorama buttons on the multiplayer screen as well as on the local world selection screen. Panoramas from multiplayer are identified by the server address, which means that it matters which port the localhost is on (unfortunately it's random by default).

Known Issues:
- Sometimes the button to apply the panorama doesn't work. In that case turn off hiding panoramas resource packs in mod settings and enable the pack manually.